### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/blank.yml
+++ b/.github/workflows/blank.yml
@@ -1,6 +1,8 @@
 # This is a basic workflow to help you get started with Actions
 
 name: CI
+permissions:
+  contents: read
 
 # Controls when the workflow will run
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/Org-EthereaLogic/DevDocAI/security/code-scanning/1](https://github.com/Org-EthereaLogic/DevDocAI/security/code-scanning/1)

To fix the problem, we should explicitly set the minimal required permissions at the workflow or job level. Since this workflow only checks out code and echoes strings, it requires only read access to `contents`. The best fix is to add a `permissions:` block at the root of the workflow (top-level, just below the `name:`/before `on:`), setting `contents: read`. This reduces the action token privileges for all jobs in the workflow, guarding against accidental privilege escalation in the future and adhering to best practices.

**File to change:** .github/workflows/blank.yml  
**Region to change:** Near the top, just after the `name: CI` line, before or after `on:`, before `jobs:`.  
No new imports or definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
